### PR TITLE
Communications guidelines

### DIFF
--- a/content/community.Rmd
+++ b/content/community.Rmd
@@ -1,0 +1,13 @@
+---
+title: "Community"
+output: html_document
+---
+
+Interested in engaging with the R community? Here are some options. Are you part of an R group and don't see your group here? Contact us!
+
+- [R Ladies](https://rladies.org/): world-wide groups promoting gender diversity in the R community, holding in-person meetups. Open to everyone.
+- [UBC's R study group](https://libcal.library.ubc.ca/event/3511389): UBC-based group of passionate useRs who organize meetups on campus to share R knowledge.
+- [Tidy Tuesday](https://github.com/rfordatascience/tidytuesday): An online group that posts regular data projects and showcases responses. 
+- [Vancouver R Users Group](https://www.meetup.com/Vancouver-R-Users-Group-data-analysis-statistics/): A meetup.com group dedicated to teaching and sharing R. 
+- [rstudio::conf()](https://rstudio.com/conference/): Annual global conference about R and data science.
+- [BCCHR Trainee Omics Group](https://www.bcchr.ca/tog) A motivated group of graduate students, postdoctoral fellows, and staff at BC Children's Hospital Research Institute to provide a resources for data analysis skills. Mostly R, but also some other tools.

--- a/content/community.html
+++ b/content/community.html
@@ -1,0 +1,16 @@
+---
+title: "Community"
+output: html_document
+---
+
+
+
+<p>Interested in engaging with the R community? Here are some options. Are you part of an R group and don’t see your group here? Contact us!</p>
+<ul>
+<li><a href="https://rladies.org/">R Ladies</a>: world-wide groups promoting gender diversity in the R community, holding in-person meetups. Open to everyone.</li>
+<li><a href="https://libcal.library.ubc.ca/event/3511389">UBC’s R study group</a>: UBC-based group of passionate useRs who organize meetups on campus to share R knowledge.</li>
+<li><a href="https://github.com/rfordatascience/tidytuesday">Tidy Tuesday</a>: An online group that posts regular data projects and showcases responses.</li>
+<li><a href="https://www.meetup.com/Vancouver-R-Users-Group-data-analysis-statistics/">Vancouver R Users Group</a>: A meetup.com group dedicated to teaching and sharing R.</li>
+<li><a href="https://rstudio.com/conference/">rstudio::conf()</a>: Annual global conference about R and data science.</li>
+<li><a href="https://www.bcchr.ca/tog">BCCHR Trainee Omics Group</a> A motivated group of graduate students, postdoctoral fellows, and staff at BC Children’s Hospital Research Institute to provide a resources for data analysis skills. Mostly R, but also some other tools.</li>
+</ul>

--- a/content/home/contact.md
+++ b/content/home/contact.md
@@ -4,7 +4,7 @@ headless = true  # This file represents a page section.
 active = true  # Activate this widget? true/false
 weight = 80  # Order that this section will appear.
 
-title = "Let's Talk"
+title = "Connect"
 
 [[feature]]
   icon = "bullhorn"
@@ -17,6 +17,12 @@ title = "Let's Talk"
   icon_pack = "fab"
   name = "[Discussion](/slack_communication)"
   description = "preferably on the STAT 545 Slack channel!"  
+
+[[feature]]
+  icon = "users"
+  icon_pack = "fas"
+  name = "[Community](/community)"
+  description = "Join different R communities"  
 +++
 
 Want to get in touch? Here are some options.

--- a/content/home/contact.md
+++ b/content/home/contact.md
@@ -15,14 +15,8 @@ title = "Let's Talk"
 [[feature]]
   icon = "slack"
   icon_pack = "fab"
-  name = "[Discussion](https://stat545ubc.slack.com)"
-  description = "Discuss the course through the STAT 545 Slack channel!"  
-  
-[[feature]]
-  icon = "envelope"
-  icon_pack = "far"
-  name = "[Private Message](/private_message)"
-  description = "Send a private message through Slack, or send an email "
+  name = "[Discussion](/slack_communication)"
+  description = "preferably on the STAT 545 Slack channel!"  
 +++
 
 Want to get in touch? Here are some options.

--- a/content/slack_communication.Rmd
+++ b/content/slack_communication.Rmd
@@ -5,7 +5,7 @@ output: html_document
 
 # How to use Slack, and for what
 
-Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Join it by clicking this [link](stat545ubc.slack.com).
+Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Students will be given the Slack invite link at the beginning of the semester.
 
 We prefer Slack for all communications but in some cases you can email us instead. Find emails on the [teaching team](https://stat545.stat.ubc.ca/#team) section.
 

--- a/content/slack_communication.Rmd
+++ b/content/slack_communication.Rmd
@@ -1,0 +1,96 @@
+---
+title: "Using Slack"
+output: html_document
+---
+
+# How to use Slack, and for what
+
+Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Join it by clicking this [link](stat545ubc.slack.com).
+
+We prefer Slack for all communications but in some cases you can email us instead. Find emails on the [teaching team](https://stat545.stat.ubc.ca/#team) section.
+
+The teaching team can’t guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a 17:00 PST cutoff on Fridays when asking assignment-related questions.
+
+### Use the _#general_ channel for most communications
+
+TAs, Vincenzo and other students can participate and benefit from these conversations. Examples of appropriate topics for _#general_ are described below:
+
+#### Clarifying concepts from lectures
+
+Examples: 
+
+> What's the difference between a `tibble` and a `data.frame`?
+
+> Does `set.seed()` work on all computers (OS) and versions of R?
+
+> Is there a difference between `[]` and `[[]]`?
+
+#### Asking about course organization
+
+e.g. the syllabus, course policies, assignment deadlines...
+
+Examples:
+
+> When is the deadline for Assignment 1?
+
+> For next lecture on Tuesday, are we going to be reviewing the upcoming project?
+
+#### Clarifying instructions in assignments and other deliverables
+
+Ping the TA or instructor if you know which person developed the instructions (`@Name-of-TA-or-instructor`).
+
+Examples:
+
+> For assignment 1a, question 3, can I pick any character variable in my dataset or does it need to be one with 3 or more categories? @Victor
+
+> For assignment 2, do I use the same dataset that I used in assignment 1?
+
+
+#### When you are stuck and need help
+
+On assignments, workshops, group projects.
+
+Examples:
+
+> For worksheet 4, question 2.1, I can't seem to get the correct answer. Here is my code:
+>
+> ```
+> answer2.1 <- mtcars %>% 
+>      nest(cyl) %>%
+>      ...
+> ```
+
+> For assignment 3, I keep getting an error when installing the package `distplyr`. This is the code  and error message: `...code and errors...`
+
+Post an appropriate amount of details to get the help you want. Ideally use [`reprex`](https://www.tidyverse.org/help/), but at minimum provide your code, and any error messages.
+
+### When to message a TA or Vincenzo privately
+
+If you are still stuck **after** trying _#general_, then you can message a TA for more help. Instead messaging just one TA, please consider making a group chat and message all of the TAs, so that the most available TA can help.
+
+Example situations:
+
+> "Hi TAs, I posted in _#general_ for help, but I'm still stuck on question 2.1 of worksheet 4. Can I get some help to work through this?"
+
+If a TA feels that your message is inappropriate for a private conversation (e.g. it might be helpful for other students to see), they may redirect you to posting in the _#general_ channel. 
+
+#### When you have questions or concerns about your grades
+
+Either post an issue on your homework repo (preferred), or contact the marking TA on slack.
+
+*Only message Vincenzo if you are still unsatistified with your grade, after talking with your TA*
+
+#### When you have need a deadline extension
+
+Contact your TA if it's only for one upcoming deadline. If you need multiple deadline extensions for an extenuating circumstance, consider contacting Vincenzo
+
+#### When there is conflict with another student in a group project
+
+For example, when you feel that your partner is not pulling their weight.
+
+# Other guidelines for using Slack
+
+- Use [**threads**](https://slack.com/intl/en-ca/help/articles/115000769927-Use-threads-to-organize-discussions-) to keep conversations organized
+
+- If posting code, use \`\`\` (backticks). It's way easier to read. Even better, use [`reprex`](https://www.tidyverse.org/help/)
+

--- a/content/slack_communication.html
+++ b/content/slack_communication.html
@@ -7,7 +7,7 @@ output: html_document
 
 <div id="how-to-use-slack-and-for-what" class="section level1">
 <h1>How to use Slack, and for what</h1>
-<p>Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Join it by clicking this <a href="stat545ubc.slack.com">link</a>.</p>
+<p>Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Students will be given the Slack invite link at the beginning of the semester.</p>
 <p>We prefer Slack for all communications but in some cases you can email us instead. Find emails on the <a href="https://stat545.stat.ubc.ca/#team">teaching team</a> section.</p>
 <p>The teaching team can’t guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a 17:00 PST cutoff on Fridays when asking assignment-related questions.</p>
 <div id="use-the-general-channel-for-most-communications" class="section level3">

--- a/content/slack_communication.html
+++ b/content/slack_communication.html
@@ -1,0 +1,96 @@
+---
+title: "Using Slack"
+output: html_document
+---
+
+
+
+<div id="how-to-use-slack-and-for-what" class="section level1">
+<h1>How to use Slack, and for what</h1>
+<p>Slack is the main forum for STAT 545 for discussion between students, TAs, and the instructor. Join it by clicking this <a href="stat545ubc.slack.com">link</a>.</p>
+<p>We prefer Slack for all communications but in some cases you can email us instead. Find emails on the <a href="https://stat545.stat.ubc.ca/#team">teaching team</a> section.</p>
+<p>The teaching team can’t guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a 17:00 PST cutoff on Fridays when asking assignment-related questions.</p>
+<div id="use-the-general-channel-for-most-communications" class="section level3">
+<h3>Use the <em>#general</em> channel for most communications</h3>
+<p>TAs, Vincenzo and other students can participate and benefit from these conversations. Examples of appropriate topics for <em>#general</em> are described below:</p>
+<div id="clarifying-concepts-from-lectures" class="section level4">
+<h4>Clarifying concepts from lectures</h4>
+<p>Examples:</p>
+<blockquote>
+<p>What’s the difference between a <code>tibble</code> and a <code>data.frame</code>?</p>
+</blockquote>
+<blockquote>
+<p>Does <code>set.seed()</code> work on all computers (OS) and versions of R?</p>
+</blockquote>
+<blockquote>
+<p>Is there a difference between <code>[]</code> and <code>[[]]</code>?</p>
+</blockquote>
+</div>
+<div id="asking-about-course-organization" class="section level4">
+<h4>Asking about course organization</h4>
+<p>e.g. the syllabus, course policies, assignment deadlines…</p>
+<p>Examples:</p>
+<blockquote>
+<p>When is the deadline for Assignment 1?</p>
+</blockquote>
+<blockquote>
+<p>For next lecture on Tuesday, are we going to be reviewing the upcoming project?</p>
+</blockquote>
+</div>
+<div id="clarifying-instructions-in-assignments-and-other-deliverables" class="section level4">
+<h4>Clarifying instructions in assignments and other deliverables</h4>
+<p>Ping the TA or instructor if you know which person developed the instructions (<code>@Name-of-TA-or-instructor</code>).</p>
+<p>Examples:</p>
+<blockquote>
+<p>For assignment 1a, question 3, can I pick any character variable in my dataset or does it need to be one with 3 or more categories? <span class="citation">@Victor</span></p>
+</blockquote>
+<blockquote>
+<p>For assignment 2, do I use the same dataset that I used in assignment 1?</p>
+</blockquote>
+</div>
+<div id="when-you-are-stuck-and-need-help" class="section level4">
+<h4>When you are stuck and need help</h4>
+<p>On assignments, workshops, group projects.</p>
+<p>Examples:</p>
+<blockquote>
+<p>For worksheet 4, question 2.1, I can’t seem to get the correct answer. Here is my code:</p>
+<pre><code>answer2.1 &lt;- mtcars %&gt;% 
+     nest(cyl) %&gt;%
+     ...</code></pre>
+</blockquote>
+<blockquote>
+<p>For assignment 3, I keep getting an error when installing the package <code>distplyr</code>. This is the code and error message: <code>...code and errors...</code></p>
+</blockquote>
+<p>Post an appropriate amount of details to get the help you want. Ideally use <a href="https://www.tidyverse.org/help/"><code>reprex</code></a>, but at minimum provide your code, and any error messages.</p>
+</div>
+</div>
+<div id="when-to-message-a-ta-or-vincenzo-privately" class="section level3">
+<h3>When to message a TA or Vincenzo privately</h3>
+<p>If you are still stuck <strong>after</strong> trying <em>#general</em>, then you can message a TA for more help. Instead messaging just one TA, please consider making a group chat and message all of the TAs, so that the most available TA can help.</p>
+<p>Example situations:</p>
+<blockquote>
+<p>“Hi TAs, I posted in <em>#general</em> for help, but I’m still stuck on question 2.1 of worksheet 4. Can I get some help to work through this?”</p>
+</blockquote>
+<p>If a TA feels that your message is inappropriate for a private conversation (e.g. it might be helpful for other students to see), they may redirect you to posting in the <em>#general</em> channel.</p>
+<div id="when-you-have-questions-or-concerns-about-your-grades" class="section level4">
+<h4>When you have questions or concerns about your grades</h4>
+<p>Either post an issue on your homework repo (preferred), or contact the marking TA on slack.</p>
+<p><em>Only message Vincenzo if you are still unsatistified with your grade, after talking with your TA</em></p>
+</div>
+<div id="when-you-have-need-a-deadline-extension" class="section level4">
+<h4>When you have need a deadline extension</h4>
+<p>Contact your TA if it’s only for one upcoming deadline. If you need multiple deadline extensions for an extenuating circumstance, consider contacting Vincenzo</p>
+</div>
+<div id="when-there-is-conflict-with-another-student-in-a-group-project" class="section level4">
+<h4>When there is conflict with another student in a group project</h4>
+<p>For example, when you feel that your partner is not pulling their weight.</p>
+</div>
+</div>
+</div>
+<div id="other-guidelines-for-using-slack" class="section level1">
+<h1>Other guidelines for using Slack</h1>
+<ul>
+<li><p>Use <a href="https://slack.com/intl/en-ca/help/articles/115000769927-Use-threads-to-organize-discussions-"><strong>threads</strong></a> to keep conversations organized</p></li>
+<li><p>If posting code, use ``` (backticks). It’s way easier to read. Even better, use <a href="https://www.tidyverse.org/help/"><code>reprex</code></a></p></li>
+</ul>
+</div>

--- a/content/syllabus-545a.Rmd
+++ b/content/syllabus-545a.Rmd
@@ -121,7 +121,8 @@ In addition to [UBC's Campus-wide Policies and Regulations](http://www.calendar.
 ## Communications
 
 The teaching team can't guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a __17:00 PST cutoff on Fridays__ when asking assignment-related questions. 
-  
+
+Please read [this](/slack_communication) before messaging the teaching team.
 
 ## Late Policy
 

--- a/content/syllabus-545a.html
+++ b/content/syllabus-545a.html
@@ -227,6 +227,7 @@ output:
 <div id="communications" class="section level2">
 <h2>Communications</h2>
 <p>The teaching team can’t guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a <strong>17:00 PST cutoff on Fridays</strong> when asking assignment-related questions.</p>
+<p>Please read <a href="/slack_communication">this</a> before messaging the teaching team.</p>
 </div>
 <div id="late-policy" class="section level2">
 <h2>Late Policy</h2>

--- a/content/syllabus-545b.Rmd
+++ b/content/syllabus-545b.Rmd
@@ -107,7 +107,8 @@ In addition to [UBC's Campus-wide Policies and Regulations](http://www.calendar.
 ## Communications
 
 The teaching team can't guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a __17:00 PST cutoff on Fridays__ when asking assignment-related questions. 
-  
+
+Please read [this](/slack_communication) before messaging the teaching team.
 
 ## Late Policy
 

--- a/content/syllabus-545b.Rmd
+++ b/content/syllabus-545b.Rmd
@@ -102,7 +102,7 @@ STAT 545 asks students to work on github.com. Please produce work knowing that t
 
 # Policies
 
-In addition to [UBC's Campus-wide Policies and Regulations](http://www.calendar.ubc.ca/vancouver/?tree=3,0,0,0), STAT 545A and STAT 547M adopt the following policies.
+In addition to [UBC's Campus-wide Policies and Regulations](http://www.calendar.ubc.ca/vancouver/?tree=3,0,0,0), STAT 545A and STAT 545B adopt the following policies.
 
 ## Communications
 

--- a/content/syllabus-545b.html
+++ b/content/syllabus-545b.html
@@ -186,10 +186,11 @@ output:
 </div>
 <div id="policies" class="section level1">
 <h1>Policies</h1>
-<p>In addition to <a href="http://www.calendar.ubc.ca/vancouver/?tree=3,0,0,0">UBC’s Campus-wide Policies and Regulations</a>, STAT 545A and STAT 547M adopt the following policies.</p>
+<p>In addition to <a href="http://www.calendar.ubc.ca/vancouver/?tree=3,0,0,0">UBC’s Campus-wide Policies and Regulations</a>, STAT 545A and STAT 545B adopt the following policies.</p>
 <div id="communications" class="section level2">
 <h2>Communications</h2>
 <p>The teaching team can’t guarantee that they will be able to respond to student messages outside of typical workday hours (0900-1700 PST). So, please be mindful of a <strong>17:00 PST cutoff on Fridays</strong> when asking assignment-related questions.</p>
+<p>Please read <a href="/slack_communication">this</a> before messaging the teaching team.</p>
 </div>
 <div id="late-policy" class="section level2">
 <h2>Late Policy</h2>


### PR DESCRIPTION
I [added](7f0ced7) a [`communications guidelines` / `how to use slack`](https://github.com/UBC-STAT/stat545.stat.ubc.ca/blob/communications_guidelines/content/slack_communication.Rmd) page. 

Added link to this page on the `let's talk` section of the homepage. I also [removed](a247bb7) the `private message` link, since it is now redundant with the old page. But the "widgets" are not centered for some reason.

Added links to the `#Communications` sections in the syllabuses.

Let me know if anybody wants any changes on the proposed structure or content.  Or feel free to edit directly!



